### PR TITLE
[data exploration] Matching Sirius <> Orbis, Chambre et libellé

### DIFF
--- a/.ipynb_checkpoints/ap_hp_exploration-checkpoint.ipynb
+++ b/.ipynb_checkpoints/ap_hp_exploration-checkpoint.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 220,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 221,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,12 +95,15 @@
     "# Extract hospital name from U.Responsabilité (e.g: ABC from 028081 - ABC OBSTETRIQUE (UF))\n",
     "orbis['hospital_name'] = orbis['U.Responsabilité'].str.split(r\"\\ - \", expand=True)[1].str[0:3]\n",
     "\n",
+    "# From room, remove white spaces and uppercase\n",
+    "orbis['room'] = orbis['room'].str.replace(' ', '').str.upper()\n",
+    "\n",
     "orbis = orbis[['ipp', 'code_room', 'room', 'hospital_name']]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 224,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 227,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,15 +160,20 @@
     "                       'Libelle Chambre':'label_room'},\n",
     "             inplace=True)\n",
     "\n",
-    "sirius['label_room'] = sirius['label_room'].astype(str)\n",
-    "sirius['code_room'] = sirius['code_room'].astype(str)\n",
-    "\n",
     "# only filter row with OUI \n",
     "sirius = sirius.query(\"filter_row=='OUI'\")\n",
     "\n",
+    "# remove white spaces from label room, uppercase \n",
+    "sirius['label_room'] = sirius['label_room'].astype(str)\n",
+    "sirius['label_room'] = sirius['label_room'].str.replace(' ', '').str.upper()\n",
+    "\n",
+    "# remove white spaces from code room, uppercase \n",
+    "sirius['code_room'] = sirius['code_room'].astype(str)\n",
+    "sirius['code_room'] = sirius['code_room'].str.replace(' ', '').str.upper()\n",
+    "\n",
     "#create room as concatenate of code_room and label_room\n",
     "\n",
-    "sirius['room'] = sirius[['code_room', 'label_room']].agg(' - '.join, axis=1)\n",
+    "sirius['room'] = sirius[['code_room', 'label_room']].agg('-'.join, axis=1)\n",
     "\n",
     "sirius.drop('filter_row', axis=1, inplace=True)"
    ]
@@ -179,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 229,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -348,17 +356,17 @@
       ],
       "text/plain": [
        "             ipp code_room room hospital_name  is_pcr  radio  is_covid\n",
-       "118   8003232267             -            ABC     1.0    0.0         1\n",
-       "381   8014201282             -            APR     1.0    0.0         1\n",
-       "402   8001043127             -            APR     1.0    0.0         1\n",
-       "760   8014207211             -            BCT     1.0    0.0         1\n",
-       "780   8014213145             -            BCT     1.0    0.0         1\n",
-       "821   8008578325             -            BCT     1.0    0.0         1\n",
-       "1182  8014232794             -            BCT     1.0    0.0         1\n",
-       "1301  8008890155             -            BCT     1.0    0.0         1"
+       "118   8003232267              -           ABC     1.0    0.0         1\n",
+       "381   8014201282              -           APR     1.0    0.0         1\n",
+       "402   8001043127              -           APR     1.0    0.0         1\n",
+       "760   8014207211              -           BCT     1.0    0.0         1\n",
+       "780   8014213145              -           BCT     1.0    0.0         1\n",
+       "821   8008578325              -           BCT     1.0    0.0         1\n",
+       "1182  8014232794              -           BCT     1.0    0.0         1\n",
+       "1301  8008890155              -           BCT     1.0    0.0         1"
       ]
      },
-     "execution_count": 230,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -376,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,14 +425,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "il y a 294 chambres Orbis qu'on ne retrouve pas dans Sirius\n"
+      "il y a 195 chambres Orbis qu'on ne retrouve pas dans Sirius\n"
      ]
     }
    ],
@@ -443,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,14 +471,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 235,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "il y a 98 patients dans Orbis sans chambre. Reste a expliquer 196 patients\n"
+      "il y a 98 patients dans Orbis sans chambre. Reste a expliquer 97 patients\n"
      ]
     }
    ],
@@ -486,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -542,9 +550,9 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>0</th>\n",
        "      <td>04</td>\n",
-       "      <td>04 - CHAMBRE 04 USR</td>\n",
+       "      <td>04-CHAMBRE04USR</td>\n",
        "      <td>BCT</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -552,9 +560,9 @@
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>2</th>\n",
        "      <td>04</td>\n",
-       "      <td>04 - CHAMBRE 04 USR</td>\n",
+       "      <td>04-CHAMBRE04USR</td>\n",
        "      <td>BCT</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -566,16 +574,16 @@
        "</div>"
       ],
       "text/plain": [
-       "  code_room               room_x hospital_name  code_hospital covid_service  \\\n",
-       "2        04  04 - CHAMBRE 04 USR           BCT            NaN           NaN   \n",
-       "4        04  04 - CHAMBRE 04 USR           BCT            NaN           NaN   \n",
+       "  code_room           room_x hospital_name  code_hospital covid_service  \\\n",
+       "0        04  04-CHAMBRE04USR           BCT            NaN           NaN   \n",
+       "2        04  04-CHAMBRE04USR           BCT            NaN           NaN   \n",
        "\n",
        "  label_room room_y  \n",
-       "2        NaN    NaN  \n",
-       "4        NaN    NaN  "
+       "0        NaN    NaN  \n",
+       "2        NaN    NaN  "
       ]
      },
-     "execution_count": 237,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -586,7 +594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -623,18 +631,18 @@
        "      <th>3148</th>\n",
        "      <td>10</td>\n",
        "      <td>ZSTCD ADULTES</td>\n",
-       "      <td>CHAMBRE SEULE 04</td>\n",
+       "      <td>CHAMBRESEULE04</td>\n",
        "      <td>4</td>\n",
-       "      <td>4 - CHAMBRE SEULE 04</td>\n",
+       "      <td>4-CHAMBRESEULE04</td>\n",
        "      <td>BCT</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3953</th>\n",
        "      <td>10</td>\n",
        "      <td>USR</td>\n",
-       "      <td>CHAMBRE 04 USR</td>\n",
+       "      <td>CHAMBRE04USR</td>\n",
        "      <td>4</td>\n",
-       "      <td>4 - CHAMBRE 04 USR</td>\n",
+       "      <td>4-CHAMBRE04USR</td>\n",
        "      <td>BCT</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -642,16 +650,16 @@
        "</div>"
       ],
       "text/plain": [
-       "      code_hospital  covid_service        label_room code_room  \\\n",
-       "3148             10  ZSTCD ADULTES  CHAMBRE SEULE 04         4   \n",
-       "3953             10            USR    CHAMBRE 04 USR         4   \n",
+       "      code_hospital  covid_service      label_room code_room  \\\n",
+       "3148             10  ZSTCD ADULTES  CHAMBRESEULE04         4   \n",
+       "3953             10            USR    CHAMBRE04USR         4   \n",
        "\n",
-       "                      room hospital_name  \n",
-       "3148  4 - CHAMBRE SEULE 04           BCT  \n",
-       "3953    4 - CHAMBRE 04 USR           BCT  "
+       "                  room hospital_name  \n",
+       "3148  4-CHAMBRESEULE04           BCT  \n",
+       "3953    4-CHAMBRE04USR           BCT  "
       ]
      },
-     "execution_count": 238,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -669,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 239,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -704,9 +712,9 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>212</th>\n",
+       "      <th>101</th>\n",
        "      <td>003</td>\n",
-       "      <td>003 - SALLE 3</td>\n",
+       "      <td>003-SALLE3</td>\n",
        "      <td>RPC</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -718,14 +726,14 @@
        "</div>"
       ],
       "text/plain": [
-       "    code_room         room_x hospital_name  code_hospital covid_service  \\\n",
-       "212       003  003 - SALLE 3           RPC            NaN           NaN   \n",
+       "    code_room      room_x hospital_name  code_hospital covid_service  \\\n",
+       "101       003  003-SALLE3           RPC            NaN           NaN   \n",
        "\n",
        "    label_room room_y  \n",
-       "212        NaN    NaN  "
+       "101        NaN    NaN  "
       ]
      },
-     "execution_count": 239,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -736,7 +744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 240,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -773,9 +781,9 @@
        "      <th>1402</th>\n",
        "      <td>68</td>\n",
        "      <td>WIDAL 1 S2 - COVID +</td>\n",
-       "      <td>SALLE 3</td>\n",
+       "      <td>SALLE3</td>\n",
        "      <td>3</td>\n",
-       "      <td>3 - SALLE 3</td>\n",
+       "      <td>3-SALLE3</td>\n",
        "      <td>RPC</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -783,14 +791,14 @@
        "</div>"
       ],
       "text/plain": [
-       "      code_hospital          covid_service label_room code_room         room  \\\n",
-       "1402             68  WIDAL 1 S2 - COVID +     SALLE 3         3  3 - SALLE 3   \n",
+       "      code_hospital          covid_service label_room code_room      room  \\\n",
+       "1402             68  WIDAL 1 S2 - COVID +      SALLE3         3  3-SALLE3   \n",
        "\n",
        "     hospital_name  \n",
        "1402           RPC  "
       ]
      },
-     "execution_count": 240,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -808,7 +816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -843,9 +851,9 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>55</th>\n",
+       "      <th>35</th>\n",
        "      <td>L205</td>\n",
-       "      <td>L205 - CHAMBRE 5 LAENNEC 0205</td>\n",
+       "      <td>L205-CHAMBRE5LAENNEC0205</td>\n",
        "      <td>BCT</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -857,14 +865,14 @@
        "</div>"
       ],
       "text/plain": [
-       "   code_room                         room_x hospital_name  code_hospital  \\\n",
-       "55      L205  L205 - CHAMBRE 5 LAENNEC 0205           BCT            NaN   \n",
+       "   code_room                    room_x hospital_name  code_hospital  \\\n",
+       "35      L205  L205-CHAMBRE5LAENNEC0205           BCT            NaN   \n",
        "\n",
        "   covid_service label_room room_y  \n",
-       "55           NaN        NaN    NaN  "
+       "35           NaN        NaN    NaN  "
       ]
      },
-     "execution_count": 241,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -875,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -912,9 +920,9 @@
        "      <th>1412</th>\n",
        "      <td>68</td>\n",
        "      <td>WIDAL 2 S1 - COVID +</td>\n",
-       "      <td>CHAMBRE 205</td>\n",
+       "      <td>CHAMBRE205</td>\n",
        "      <td>205</td>\n",
-       "      <td>205 - CHAMBRE 205</td>\n",
+       "      <td>205-CHAMBRE205</td>\n",
        "      <td>RPC</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -922,14 +930,14 @@
        "</div>"
       ],
       "text/plain": [
-       "      code_hospital          covid_service   label_room code_room  \\\n",
-       "1412             68  WIDAL 2 S1 - COVID +   CHAMBRE 205       205   \n",
+       "      code_hospital          covid_service  label_room code_room  \\\n",
+       "1412             68  WIDAL 2 S1 - COVID +   CHAMBRE205       205   \n",
        "\n",
-       "                   room hospital_name  \n",
-       "1412  205 - CHAMBRE 205           RPC  "
+       "                room hospital_name  \n",
+       "1412  205-CHAMBRE205           RPC  "
       ]
      },
-     "execution_count": 242,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -940,14 +948,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 243,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "il y a 45 patients dont le code chambre Sirius ne correspond pas dans Orbis. Reste a expliquer 151 patients\n"
+      "il y a 45 patients dont le code chambre Sirius ne correspond pas dans Orbis. Reste a expliquer 52 patients\n"
      ]
     }
    ],
@@ -964,7 +972,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -977,117 +984,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": 54,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>room_orbis</th>\n",
-       "      <th>room_sirius</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>C134 - CHAMBRE SEULE C134</td>\n",
-       "      <td>C134 - CHAMBRE SEULE C134</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>C134 - CHAMBRE SEULE C134</td>\n",
-       "      <td>C134 - CHAMBRE SEULE C134</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>N05 - CHAMBRE 5 NEO NATALE</td>\n",
-       "      <td>N05 - Chambre 5 Neo Natale</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>N07 - CHAMBRE 7 NEO NATALE</td>\n",
-       "      <td>N07 - Chambre 7 Neo Natale</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>218 - CHAMBRE 218 M2I</td>\n",
-       "      <td>218 - chambre 218 M2I</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>207</th>\n",
-       "      <td>N109 - CHAMBRE 09</td>\n",
-       "      <td>N109 - CHAMBRE 09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>210</th>\n",
-       "      <td>N309 - CHAMBRE 09</td>\n",
-       "      <td>N309 - CHAMBRE 09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>213</th>\n",
-       "      <td>N103 - CHAMBRE 03</td>\n",
-       "      <td>N103 - CHAMBRE 03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>214</th>\n",
-       "      <td>N308 - CHAMBRE 08</td>\n",
-       "      <td>N308 - CHAMBRE 08</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>215</th>\n",
-       "      <td>N304 - CHAMBRE 04</td>\n",
-       "      <td>N304 - CHAMBRE 04</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>163 rows × 2 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                     room_orbis                 room_sirius\n",
-       "0     C134 - CHAMBRE SEULE C134  C134 - CHAMBRE SEULE C134 \n",
-       "1     C134 - CHAMBRE SEULE C134  C134 - CHAMBRE SEULE C134 \n",
-       "7    N05 - CHAMBRE 5 NEO NATALE  N05 - Chambre 5 Neo Natale\n",
-       "9    N07 - CHAMBRE 7 NEO NATALE  N07 - Chambre 7 Neo Natale\n",
-       "17        218 - CHAMBRE 218 M2I       218 - chambre 218 M2I\n",
-       "..                          ...                         ...\n",
-       "207           N109 - CHAMBRE 09          N109 - CHAMBRE 09 \n",
-       "210           N309 - CHAMBRE 09          N309 - CHAMBRE 09 \n",
-       "213           N103 - CHAMBRE 03          N103 - CHAMBRE 03 \n",
-       "214           N308 - CHAMBRE 08          N308 - CHAMBRE 08 \n",
-       "215           N304 - CHAMBRE 04          N304 - CHAMBRE 04 \n",
-       "\n",
-       "[163 rows x 2 columns]"
-      ]
-     },
-     "execution_count": 244,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_gap.query(\"code_hospital.notnull()\")[['room_x', \n",
     "                                         'room_y']]\\\n",
@@ -1097,14 +996,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "il y a 119 patients avec une difference de label . Reste a expliquer 32 patients\n"
+      "il y a 40 patients avec une difference de label . Reste a expliquer 12 patients\n"
      ]
     }
    ],
@@ -1130,7 +1029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1162,7 +1061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 435,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -1201,7 +1100,7 @@
        "      <td>CHIR DIG/GYNECO/ORTHO MUTUALISE</td>\n",
        "      <td>5</td>\n",
        "      <td>0</td>\n",
-       "      <td>8</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1210,16 +1109,16 @@
        "      <td>COVID 12 (REA/SC)</td>\n",
        "      <td>9</td>\n",
        "      <td>6</td>\n",
-       "      <td>8</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>8.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>ABC</td>\n",
        "      <td>COVID 14</td>\n",
-       "      <td>24</td>\n",
+       "      <td>11</td>\n",
        "      <td>7</td>\n",
-       "      <td>14</td>\n",
+       "      <td>14.0</td>\n",
        "      <td>14.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1228,7 +1127,7 @@
        "      <td>COVID 30</td>\n",
        "      <td>27</td>\n",
        "      <td>19</td>\n",
-       "      <td>30</td>\n",
+       "      <td>30.0</td>\n",
        "      <td>30.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1237,36 +1136,105 @@
        "      <td>HGE</td>\n",
        "      <td>24</td>\n",
        "      <td>0</td>\n",
+       "      <td>27.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>107</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>UGA DEBUSSY - COVID +</td>\n",
+       "      <td>21</td>\n",
+       "      <td>17</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>108</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>USLD BIZET</td>\n",
+       "      <td>30</td>\n",
+       "      <td>3</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>USLD VERDI</td>\n",
        "      <td>27</td>\n",
+       "      <td>13</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>110</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>USP GATINEAU</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>111</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>USPC</td>\n",
+       "      <td>18</td>\n",
+       "      <td>0</td>\n",
+       "      <td>18.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
+       "<p>112 rows × 6 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "  hospital_name                    covid_service  ipp  is_covid lits_ouverts  \\\n",
-       "0           ABC  CHIR DIG/GYNECO/ORTHO MUTUALISE    5         0            8   \n",
-       "1           ABC                COVID 12 (REA/SC)    9         6            8   \n",
-       "2           ABC                         COVID 14   24         7           14   \n",
-       "3           ABC                         COVID 30   27        19           30   \n",
-       "4           ABC                              HGE   24         0           27   \n",
+       "    hospital_name                    covid_service  ipp  is_covid  \\\n",
+       "0             ABC  CHIR DIG/GYNECO/ORTHO MUTUALISE    5         0   \n",
+       "1             ABC                COVID 12 (REA/SC)    9         6   \n",
+       "2             ABC                         COVID 14   11         7   \n",
+       "3             ABC                         COVID 30   27        19   \n",
+       "4             ABC                              HGE   24         0   \n",
+       "..            ...                              ...  ...       ...   \n",
+       "107           SPR            UGA DEBUSSY - COVID +   21        17   \n",
+       "108           SPR                       USLD BIZET   30         3   \n",
+       "109           SPR                       USLD VERDI   27        13   \n",
+       "110           SPR                     USP GATINEAU    9         0   \n",
+       "111           SPR                            USPC    18         0   \n",
        "\n",
-       "   lits_ouverts_covid  \n",
-       "0                 0.0  \n",
-       "1                 8.0  \n",
-       "2                14.0  \n",
-       "3                30.0  \n",
-       "4                 0.0  "
+       "     lits_ouverts  lits_ouverts_covid  \n",
+       "0             8.0                 0.0  \n",
+       "1             8.0                 8.0  \n",
+       "2            14.0                14.0  \n",
+       "3            30.0                30.0  \n",
+       "4            27.0                 0.0  \n",
+       "..            ...                 ...  \n",
+       "107          29.0                 0.0  \n",
+       "108          33.0                 0.0  \n",
+       "109          33.0                 0.0  \n",
+       "110          10.0                 0.0  \n",
+       "111          18.0                 0.0  \n",
+       "\n",
+       "[112 rows x 6 columns]"
       ]
      },
-     "execution_count": 435,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.head()"
+    "df"
    ]
   }
  ],

--- a/ap_hp_exploration.ipynb
+++ b/ap_hp_exploration.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 220,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 221,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,12 +95,15 @@
     "# Extract hospital name from U.Responsabilité (e.g: ABC from 028081 - ABC OBSTETRIQUE (UF))\n",
     "orbis['hospital_name'] = orbis['U.Responsabilité'].str.split(r\"\\ - \", expand=True)[1].str[0:3]\n",
     "\n",
+    "# From room, remove white spaces and uppercase\n",
+    "orbis['room'] = orbis['room'].str.replace(' ', '').str.upper()\n",
+    "\n",
     "orbis = orbis[['ipp', 'code_room', 'room', 'hospital_name']]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 224,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 227,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,15 +160,20 @@
     "                       'Libelle Chambre':'label_room'},\n",
     "             inplace=True)\n",
     "\n",
-    "sirius['label_room'] = sirius['label_room'].astype(str)\n",
-    "sirius['code_room'] = sirius['code_room'].astype(str)\n",
-    "\n",
     "# only filter row with OUI \n",
     "sirius = sirius.query(\"filter_row=='OUI'\")\n",
     "\n",
+    "# remove white spaces from label room, uppercase \n",
+    "sirius['label_room'] = sirius['label_room'].astype(str)\n",
+    "sirius['label_room'] = sirius['label_room'].str.replace(' ', '').str.upper()\n",
+    "\n",
+    "# remove white spaces from code room, uppercase \n",
+    "sirius['code_room'] = sirius['code_room'].astype(str)\n",
+    "sirius['code_room'] = sirius['code_room'].str.replace(' ', '').str.upper()\n",
+    "\n",
     "#create room as concatenate of code_room and label_room\n",
     "\n",
-    "sirius['room'] = sirius[['code_room', 'label_room']].agg(' - '.join, axis=1)\n",
+    "sirius['room'] = sirius[['code_room', 'label_room']].agg('-'.join, axis=1)\n",
     "\n",
     "sirius.drop('filter_row', axis=1, inplace=True)"
    ]
@@ -179,7 +187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 229,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -348,17 +356,17 @@
       ],
       "text/plain": [
        "             ipp code_room room hospital_name  is_pcr  radio  is_covid\n",
-       "118   8003232267             -            ABC     1.0    0.0         1\n",
-       "381   8014201282             -            APR     1.0    0.0         1\n",
-       "402   8001043127             -            APR     1.0    0.0         1\n",
-       "760   8014207211             -            BCT     1.0    0.0         1\n",
-       "780   8014213145             -            BCT     1.0    0.0         1\n",
-       "821   8008578325             -            BCT     1.0    0.0         1\n",
-       "1182  8014232794             -            BCT     1.0    0.0         1\n",
-       "1301  8008890155             -            BCT     1.0    0.0         1"
+       "118   8003232267              -           ABC     1.0    0.0         1\n",
+       "381   8014201282              -           APR     1.0    0.0         1\n",
+       "402   8001043127              -           APR     1.0    0.0         1\n",
+       "760   8014207211              -           BCT     1.0    0.0         1\n",
+       "780   8014213145              -           BCT     1.0    0.0         1\n",
+       "821   8008578325              -           BCT     1.0    0.0         1\n",
+       "1182  8014232794              -           BCT     1.0    0.0         1\n",
+       "1301  8008890155              -           BCT     1.0    0.0         1"
       ]
      },
-     "execution_count": 230,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -376,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,14 +425,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "il y a 294 chambres Orbis qu'on ne retrouve pas dans Sirius\n"
+      "il y a 195 chambres Orbis qu'on ne retrouve pas dans Sirius\n"
      ]
     }
    ],
@@ -443,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,14 +471,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 235,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "il y a 98 patients dans Orbis sans chambre. Reste a expliquer 196 patients\n"
+      "il y a 98 patients dans Orbis sans chambre. Reste a expliquer 97 patients\n"
      ]
     }
    ],
@@ -486,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -542,9 +550,9 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>0</th>\n",
        "      <td>04</td>\n",
-       "      <td>04 - CHAMBRE 04 USR</td>\n",
+       "      <td>04-CHAMBRE04USR</td>\n",
        "      <td>BCT</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -552,9 +560,9 @@
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>2</th>\n",
        "      <td>04</td>\n",
-       "      <td>04 - CHAMBRE 04 USR</td>\n",
+       "      <td>04-CHAMBRE04USR</td>\n",
        "      <td>BCT</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -566,16 +574,16 @@
        "</div>"
       ],
       "text/plain": [
-       "  code_room               room_x hospital_name  code_hospital covid_service  \\\n",
-       "2        04  04 - CHAMBRE 04 USR           BCT            NaN           NaN   \n",
-       "4        04  04 - CHAMBRE 04 USR           BCT            NaN           NaN   \n",
+       "  code_room           room_x hospital_name  code_hospital covid_service  \\\n",
+       "0        04  04-CHAMBRE04USR           BCT            NaN           NaN   \n",
+       "2        04  04-CHAMBRE04USR           BCT            NaN           NaN   \n",
        "\n",
        "  label_room room_y  \n",
-       "2        NaN    NaN  \n",
-       "4        NaN    NaN  "
+       "0        NaN    NaN  \n",
+       "2        NaN    NaN  "
       ]
      },
-     "execution_count": 237,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -586,7 +594,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -623,18 +631,18 @@
        "      <th>3148</th>\n",
        "      <td>10</td>\n",
        "      <td>ZSTCD ADULTES</td>\n",
-       "      <td>CHAMBRE SEULE 04</td>\n",
+       "      <td>CHAMBRESEULE04</td>\n",
        "      <td>4</td>\n",
-       "      <td>4 - CHAMBRE SEULE 04</td>\n",
+       "      <td>4-CHAMBRESEULE04</td>\n",
        "      <td>BCT</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3953</th>\n",
        "      <td>10</td>\n",
        "      <td>USR</td>\n",
-       "      <td>CHAMBRE 04 USR</td>\n",
+       "      <td>CHAMBRE04USR</td>\n",
        "      <td>4</td>\n",
-       "      <td>4 - CHAMBRE 04 USR</td>\n",
+       "      <td>4-CHAMBRE04USR</td>\n",
        "      <td>BCT</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -642,16 +650,16 @@
        "</div>"
       ],
       "text/plain": [
-       "      code_hospital  covid_service        label_room code_room  \\\n",
-       "3148             10  ZSTCD ADULTES  CHAMBRE SEULE 04         4   \n",
-       "3953             10            USR    CHAMBRE 04 USR         4   \n",
+       "      code_hospital  covid_service      label_room code_room  \\\n",
+       "3148             10  ZSTCD ADULTES  CHAMBRESEULE04         4   \n",
+       "3953             10            USR    CHAMBRE04USR         4   \n",
        "\n",
-       "                      room hospital_name  \n",
-       "3148  4 - CHAMBRE SEULE 04           BCT  \n",
-       "3953    4 - CHAMBRE 04 USR           BCT  "
+       "                  room hospital_name  \n",
+       "3148  4-CHAMBRESEULE04           BCT  \n",
+       "3953    4-CHAMBRE04USR           BCT  "
       ]
      },
-     "execution_count": 238,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -669,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 239,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -704,9 +712,9 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>212</th>\n",
+       "      <th>101</th>\n",
        "      <td>003</td>\n",
-       "      <td>003 - SALLE 3</td>\n",
+       "      <td>003-SALLE3</td>\n",
        "      <td>RPC</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -718,14 +726,14 @@
        "</div>"
       ],
       "text/plain": [
-       "    code_room         room_x hospital_name  code_hospital covid_service  \\\n",
-       "212       003  003 - SALLE 3           RPC            NaN           NaN   \n",
+       "    code_room      room_x hospital_name  code_hospital covid_service  \\\n",
+       "101       003  003-SALLE3           RPC            NaN           NaN   \n",
        "\n",
        "    label_room room_y  \n",
-       "212        NaN    NaN  "
+       "101        NaN    NaN  "
       ]
      },
-     "execution_count": 239,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -736,7 +744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 240,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -773,9 +781,9 @@
        "      <th>1402</th>\n",
        "      <td>68</td>\n",
        "      <td>WIDAL 1 S2 - COVID +</td>\n",
-       "      <td>SALLE 3</td>\n",
+       "      <td>SALLE3</td>\n",
        "      <td>3</td>\n",
-       "      <td>3 - SALLE 3</td>\n",
+       "      <td>3-SALLE3</td>\n",
        "      <td>RPC</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -783,14 +791,14 @@
        "</div>"
       ],
       "text/plain": [
-       "      code_hospital          covid_service label_room code_room         room  \\\n",
-       "1402             68  WIDAL 1 S2 - COVID +     SALLE 3         3  3 - SALLE 3   \n",
+       "      code_hospital          covid_service label_room code_room      room  \\\n",
+       "1402             68  WIDAL 1 S2 - COVID +      SALLE3         3  3-SALLE3   \n",
        "\n",
        "     hospital_name  \n",
        "1402           RPC  "
       ]
      },
-     "execution_count": 240,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -808,7 +816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -843,9 +851,9 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>55</th>\n",
+       "      <th>35</th>\n",
        "      <td>L205</td>\n",
-       "      <td>L205 - CHAMBRE 5 LAENNEC 0205</td>\n",
+       "      <td>L205-CHAMBRE5LAENNEC0205</td>\n",
        "      <td>BCT</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -857,14 +865,14 @@
        "</div>"
       ],
       "text/plain": [
-       "   code_room                         room_x hospital_name  code_hospital  \\\n",
-       "55      L205  L205 - CHAMBRE 5 LAENNEC 0205           BCT            NaN   \n",
+       "   code_room                    room_x hospital_name  code_hospital  \\\n",
+       "35      L205  L205-CHAMBRE5LAENNEC0205           BCT            NaN   \n",
        "\n",
        "   covid_service label_room room_y  \n",
-       "55           NaN        NaN    NaN  "
+       "35           NaN        NaN    NaN  "
       ]
      },
-     "execution_count": 241,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -875,7 +883,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -912,9 +920,9 @@
        "      <th>1412</th>\n",
        "      <td>68</td>\n",
        "      <td>WIDAL 2 S1 - COVID +</td>\n",
-       "      <td>CHAMBRE 205</td>\n",
+       "      <td>CHAMBRE205</td>\n",
        "      <td>205</td>\n",
-       "      <td>205 - CHAMBRE 205</td>\n",
+       "      <td>205-CHAMBRE205</td>\n",
        "      <td>RPC</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -922,14 +930,14 @@
        "</div>"
       ],
       "text/plain": [
-       "      code_hospital          covid_service   label_room code_room  \\\n",
-       "1412             68  WIDAL 2 S1 - COVID +   CHAMBRE 205       205   \n",
+       "      code_hospital          covid_service  label_room code_room  \\\n",
+       "1412             68  WIDAL 2 S1 - COVID +   CHAMBRE205       205   \n",
        "\n",
-       "                   room hospital_name  \n",
-       "1412  205 - CHAMBRE 205           RPC  "
+       "                room hospital_name  \n",
+       "1412  205-CHAMBRE205           RPC  "
       ]
      },
-     "execution_count": 242,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -940,14 +948,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 243,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "il y a 45 patients dont le code chambre Sirius ne correspond pas dans Orbis. Reste a expliquer 151 patients\n"
+      "il y a 45 patients dont le code chambre Sirius ne correspond pas dans Orbis. Reste a expliquer 52 patients\n"
      ]
     }
    ],
@@ -964,7 +972,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -977,117 +984,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": 54,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>room_orbis</th>\n",
-       "      <th>room_sirius</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>C134 - CHAMBRE SEULE C134</td>\n",
-       "      <td>C134 - CHAMBRE SEULE C134</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>C134 - CHAMBRE SEULE C134</td>\n",
-       "      <td>C134 - CHAMBRE SEULE C134</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>N05 - CHAMBRE 5 NEO NATALE</td>\n",
-       "      <td>N05 - Chambre 5 Neo Natale</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>N07 - CHAMBRE 7 NEO NATALE</td>\n",
-       "      <td>N07 - Chambre 7 Neo Natale</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>17</th>\n",
-       "      <td>218 - CHAMBRE 218 M2I</td>\n",
-       "      <td>218 - chambre 218 M2I</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>207</th>\n",
-       "      <td>N109 - CHAMBRE 09</td>\n",
-       "      <td>N109 - CHAMBRE 09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>210</th>\n",
-       "      <td>N309 - CHAMBRE 09</td>\n",
-       "      <td>N309 - CHAMBRE 09</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>213</th>\n",
-       "      <td>N103 - CHAMBRE 03</td>\n",
-       "      <td>N103 - CHAMBRE 03</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>214</th>\n",
-       "      <td>N308 - CHAMBRE 08</td>\n",
-       "      <td>N308 - CHAMBRE 08</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>215</th>\n",
-       "      <td>N304 - CHAMBRE 04</td>\n",
-       "      <td>N304 - CHAMBRE 04</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>163 rows × 2 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                     room_orbis                 room_sirius\n",
-       "0     C134 - CHAMBRE SEULE C134  C134 - CHAMBRE SEULE C134 \n",
-       "1     C134 - CHAMBRE SEULE C134  C134 - CHAMBRE SEULE C134 \n",
-       "7    N05 - CHAMBRE 5 NEO NATALE  N05 - Chambre 5 Neo Natale\n",
-       "9    N07 - CHAMBRE 7 NEO NATALE  N07 - Chambre 7 Neo Natale\n",
-       "17        218 - CHAMBRE 218 M2I       218 - chambre 218 M2I\n",
-       "..                          ...                         ...\n",
-       "207           N109 - CHAMBRE 09          N109 - CHAMBRE 09 \n",
-       "210           N309 - CHAMBRE 09          N309 - CHAMBRE 09 \n",
-       "213           N103 - CHAMBRE 03          N103 - CHAMBRE 03 \n",
-       "214           N308 - CHAMBRE 08          N308 - CHAMBRE 08 \n",
-       "215           N304 - CHAMBRE 04          N304 - CHAMBRE 04 \n",
-       "\n",
-       "[163 rows x 2 columns]"
-      ]
-     },
-     "execution_count": 244,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df_gap.query(\"code_hospital.notnull()\")[['room_x', \n",
     "                                         'room_y']]\\\n",
@@ -1097,14 +996,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "il y a 119 patients avec une difference de label . Reste a expliquer 32 patients\n"
+      "il y a 40 patients avec une difference de label . Reste a expliquer 12 patients\n"
      ]
     }
    ],
@@ -1130,7 +1029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1045,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1162,7 +1061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 435,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -1201,7 +1100,7 @@
        "      <td>CHIR DIG/GYNECO/ORTHO MUTUALISE</td>\n",
        "      <td>5</td>\n",
        "      <td>0</td>\n",
-       "      <td>8</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1210,16 +1109,16 @@
        "      <td>COVID 12 (REA/SC)</td>\n",
        "      <td>9</td>\n",
        "      <td>6</td>\n",
-       "      <td>8</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>8.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>ABC</td>\n",
        "      <td>COVID 14</td>\n",
-       "      <td>24</td>\n",
+       "      <td>11</td>\n",
        "      <td>7</td>\n",
-       "      <td>14</td>\n",
+       "      <td>14.0</td>\n",
        "      <td>14.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1228,7 +1127,7 @@
        "      <td>COVID 30</td>\n",
        "      <td>27</td>\n",
        "      <td>19</td>\n",
-       "      <td>30</td>\n",
+       "      <td>30.0</td>\n",
        "      <td>30.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1237,36 +1136,105 @@
        "      <td>HGE</td>\n",
        "      <td>24</td>\n",
        "      <td>0</td>\n",
+       "      <td>27.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>107</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>UGA DEBUSSY - COVID +</td>\n",
+       "      <td>21</td>\n",
+       "      <td>17</td>\n",
+       "      <td>29.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>108</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>USLD BIZET</td>\n",
+       "      <td>30</td>\n",
+       "      <td>3</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>109</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>USLD VERDI</td>\n",
        "      <td>27</td>\n",
+       "      <td>13</td>\n",
+       "      <td>33.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>110</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>USP GATINEAU</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>111</th>\n",
+       "      <td>SPR</td>\n",
+       "      <td>USPC</td>\n",
+       "      <td>18</td>\n",
+       "      <td>0</td>\n",
+       "      <td>18.0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
+       "<p>112 rows × 6 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "  hospital_name                    covid_service  ipp  is_covid lits_ouverts  \\\n",
-       "0           ABC  CHIR DIG/GYNECO/ORTHO MUTUALISE    5         0            8   \n",
-       "1           ABC                COVID 12 (REA/SC)    9         6            8   \n",
-       "2           ABC                         COVID 14   24         7           14   \n",
-       "3           ABC                         COVID 30   27        19           30   \n",
-       "4           ABC                              HGE   24         0           27   \n",
+       "    hospital_name                    covid_service  ipp  is_covid  \\\n",
+       "0             ABC  CHIR DIG/GYNECO/ORTHO MUTUALISE    5         0   \n",
+       "1             ABC                COVID 12 (REA/SC)    9         6   \n",
+       "2             ABC                         COVID 14   11         7   \n",
+       "3             ABC                         COVID 30   27        19   \n",
+       "4             ABC                              HGE   24         0   \n",
+       "..            ...                              ...  ...       ...   \n",
+       "107           SPR            UGA DEBUSSY - COVID +   21        17   \n",
+       "108           SPR                       USLD BIZET   30         3   \n",
+       "109           SPR                       USLD VERDI   27        13   \n",
+       "110           SPR                     USP GATINEAU    9         0   \n",
+       "111           SPR                            USPC    18         0   \n",
        "\n",
-       "   lits_ouverts_covid  \n",
-       "0                 0.0  \n",
-       "1                 8.0  \n",
-       "2                14.0  \n",
-       "3                30.0  \n",
-       "4                 0.0  "
+       "     lits_ouverts  lits_ouverts_covid  \n",
+       "0             8.0                 0.0  \n",
+       "1             8.0                 8.0  \n",
+       "2            14.0                14.0  \n",
+       "3            30.0                30.0  \n",
+       "4            27.0                 0.0  \n",
+       "..            ...                 ...  \n",
+       "107          29.0                 0.0  \n",
+       "108          33.0                 0.0  \n",
+       "109          33.0                 0.0  \n",
+       "110          10.0                 0.0  \n",
+       "111          18.0                 0.0  \n",
+       "\n",
+       "[112 rows x 6 columns]"
       ]
      },
-     "execution_count": 435,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df.head()"
+    "df"
    ]
   }
  ],


### PR DESCRIPTION
Suite à https://github.com/martindaniel4/ap_hp_covid_19/pull/16, je join désormais sur room + label en supprimant les espaces et en mettant tout en uppercase. 

Résultat, on gagne 100 patients "matched". Il en reste une centaine soit parce que le code chambre ne matche pas, soit parce que le libellé est différent, cf: 

orbis|sirius
---|---
CHA1-CHAMBRESRMN.A1 | CHA1-CHAMBRESRMN√î√òŒ©A1
-- | --
P14-CHAMBRE14P√âDIATRIE | P14-CHAMBRE14P?DIATRIE
CHA5-CHAMBRESRMN.A5 | CHA5-CHAMBRESRMN√î√òŒ©A5
CHD4-CHAMBRESCMN.D4 | CHD4-CHAMBRESCMN√î√òŒ©D4
CHD2-CHAMBRESCMN.D2 | CHD2-CHAMBRESCMN√î√òŒ©D2

Je vais implémenter le match sur room + label dans l'app (cf cette [Trello card](https://trello.com/c/3P0OLLFS/24-match-room-libelle-joindre-sur-le-code-chambre-et-libell%C3%A9)) en faisant la même manipulation. 

@rquilliet @guillaumegaluz 
