### PR TITLE
Warnings add more details

### DIFF
--- a/src/components/results/Warnings.tsx
+++ b/src/components/results/Warnings.tsx
@@ -39,14 +39,26 @@ export default function Warnings({
 function OrbisWithNoRoomWarning({ warningObject }: { warningObject: object[] }) {
   if (!warningObject.length) return null
   
-  const noRoomsUnits = _.chain(warningObject)
-                        .countBy(d => d['U.Responsabilité'].split(' - ')[1])
-                        .pairs()
-                        .value()
-                        .join(' - ')
+  const noRoomsUnitsList = _.chain(warningObject)
+    .countBy(d => d['U.Responsabilité'].split(' - ')[1])
+    .pairs()
+    .value()
                       
   return (
-    <BulletPoint>{`${warningObject.length} patients n'ont pas de chambre dans Orbis au sein des unités suivantes: ${noRoomsUnits}`}</BulletPoint>
+    <BulletPoint>
+      {`${warningObject.length} patients n'ont pas de chambre dans Orbis au sein des unités suivantes: `}
+      <ServiceNames>
+        {noRoomsUnitsList.map(service => {
+          return (
+            <ServiceName>
+              {service[0]}
+              {' - '}
+              <span style={{ fontWeight: 600 }}>{`${service[1]} patient(s)`}</span>
+            </ServiceName>
+          )
+        })}
+      </ServiceNames>
+    </BulletPoint>
   )
 }
 
@@ -112,4 +124,17 @@ const WarningContentWrapper = styled.div`
 
 const BulletPoint = styled.li`
   margin-botton: 4px;
+`
+
+const ServiceNames = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+`
+
+const ServiceName = styled.div`
+  background-color: white;
+  padding: 2px 4px;
+  margin: 0 5px 5px 0;
+  font-style: italic;
 `


### PR DESCRIPTION
Trello card - https://trello.com/c/JIVLwd7z/50-data-warning-afficher-les-chambres-non-r%C3%A9f%C3%A9renc%C3%A9es-dans-sirius

Plus d'informations sur les mismatch Orbis Sirius et patients sans Chambre pour permettre a l'AP-HP de debugguer les erreurs entre système info 

Before 
<img width="721" alt="Screen Shot 2020-04-27 at 7 59 34 PM" src="https://user-images.githubusercontent.com/695006/80404563-abc37300-88c1-11ea-9fe6-41e0011c1cac.png">

After
<img width="1259" alt="Screen Shot 2020-04-27 at 7 54 13 PM" src="https://user-images.githubusercontent.com/695006/80404586-b3831780-88c1-11ea-8290-ea63a6d90104.png">
